### PR TITLE
Add testing for version and locate workflows

### DIFF
--- a/eplaunch/tests/utilities/test_locateworkflows.py
+++ b/eplaunch/tests/utilities/test_locateworkflows.py
@@ -76,6 +76,19 @@ class TestLocateWorkflows(unittest.TestCase):
         self.assertEqual('5.9.0', loc_wf.list_of_energyplus_versions[0]['version'])
         self.assertEqual('deadbeef01', loc_wf.list_of_energyplus_versions[0]['sha'])
 
+    def test_get_workflow_directory(self):
+
+        loc_wf = LocateWorkflows()
+        loc_wf.list_of_energyplus_versions = [
+            {'version': 1.0, 'workflow': 'first'},
+            {'version': 2.0, 'workflow': 'second'},
+            {'version': 3.0, 'workflow': 'third'}
+        ]
+        self.assertEqual('first', loc_wf.get_workflow_directory(1.0))
+        self.assertEqual('second', loc_wf.get_workflow_directory(2.0))
+        self.assertEqual('third', loc_wf.get_workflow_directory(3.0))
+        self.assertEqual('', loc_wf.get_workflow_directory(4.0))
+
     def tearDown(self):
         try:
             shutil.rmtree(self.workflow_directory)

--- a/eplaunch/tests/utilities/test_version.py
+++ b/eplaunch/tests/utilities/test_version.py
@@ -6,34 +6,51 @@ from eplaunch.utilities.version import Version
 
 class TestVersion(unittest.TestCase):
 
+    def setUp(self):
+        self.v = Version()
+
     def test_numeric_version_from_string(self):
-        v = Version()
-        self.assertEqual(v.numeric_version_from_string("8.1.0"), 80100)
-        self.assertEqual(v.numeric_version_from_string("8.8.8"), 80808)
-        self.assertEqual(v.numeric_version_from_string("8.7"), 80700)
-        self.assertEqual(v.numeric_version_from_string("8.6-dfjsuy"), 80600)
-        self.assertEqual(v.numeric_version_from_string("8.4.2-dfjsuy"), 80402)
-        self.assertEqual(v.numeric_version_from_string("7.12.13"), 71213)
+        self.assertEqual(self.v.numeric_version_from_string("8.1.0"), 80100)
+        self.assertEqual(self.v.numeric_version_from_string("8.8.8"), 80808)
+        self.assertEqual(self.v.numeric_version_from_string("8.7"), 80700)
+        self.assertEqual(self.v.numeric_version_from_string("8.6-dfjsuy"), 80600)
+        self.assertEqual(self.v.numeric_version_from_string("8.4.2-dfjsuy"), 80402)
+        self.assertEqual(self.v.numeric_version_from_string("7.12.13"), 71213)
 
     def test_line_with_no_comment(self):
-        v = Version()
-        self.assertEqual(v.line_with_no_comment(" object, ! this is a comment"), "object,")
-        self.assertEqual(v.line_with_no_comment("! this is a comment"), "")
-        self.assertEqual(v.line_with_no_comment(" object, "), "object,")
+        self.assertEqual(self.v.line_with_no_comment(" object, ! this is a comment"), "object,")
+        self.assertEqual(self.v.line_with_no_comment("! this is a comment"), "")
+        self.assertEqual(self.v.line_with_no_comment(" object, "), "object,")
 
-    def test_check_energyplus_version(self):
-        v = Version()
-
-        # the version object is on one line
+    def test_check_energyplus_version_one_line(self):
         file_path = os.path.join(os.path.dirname(__file__), "Minimal.idf")
-        is_version_found, version_string, version_number = v.check_energyplus_version(file_path)
+        is_version_found, version_string, version_number = self.v.check_energyplus_version(file_path)
         self.assertTrue(is_version_found)
         self.assertEqual(version_string, "8.9")
         self.assertEqual(version_number, 80900)
 
-        # the version object is spreads across two lines
+    def test_check_energyplus_version_two_lines(self):
         file_path = os.path.join(os.path.dirname(__file__), "Minimal2.idf")
-        is_version_found, version_string, version_number = v.check_energyplus_version(file_path)
+        is_version_found, version_string, version_number = self.v.check_energyplus_version(file_path)
         self.assertTrue(is_version_found)
         self.assertEqual(version_string, "8.9.1")
         self.assertEqual(version_number, 80901)
+
+    def test_numeric_version_from_dash_string(self):
+        dash_string = 'V0-2'
+        numeric = self.v.numeric_version_from_dash_string(dash_string)
+        self.assertEqual(numeric, 200)  # even though it has a zero appended, it comes back an integer
+        dash_string = 'V1-2-0'
+        numeric = self.v.numeric_version_from_dash_string(dash_string)
+        self.assertEqual(numeric, 10200)
+        dash_string = '2-3-0'
+        numeric = self.v.numeric_version_from_dash_string(dash_string)
+        self.assertEqual(numeric, 20300)
+        dash_string = '13-4-0'
+        numeric = self.v.numeric_version_from_dash_string(dash_string)
+        self.assertEqual(numeric, 130400)
+
+    def test_string_version_from_number(self):
+        original_number = 10000
+        string_version = self.v.string_version_from_number(original_number)
+        self.assertEqual('V010000', string_version)


### PR DESCRIPTION
This just pumps up the test coverage which had slipped a bit with Travis out of the loop.  We aren't at 100% because the transition work isn't covered, and as we discussed, most of that will be offloaded to the transition workflow now. 