### PR TITLE
Add Callback Support for Workflow Messages: Phase 1

### DIFF
--- a/eplaunch/workflows/base.py
+++ b/eplaunch/workflows/base.py
@@ -13,6 +13,9 @@ class BaseEPLaunch3Workflow(object):
     abort = False
     output_toolbar_order = None
 
+    def __init__(self):
+        self.callback = None
+
     def name(self):
         raise NotImplementedError("name function needs to be implemented in derived workflow class")
 
@@ -35,9 +38,20 @@ class BaseEPLaunch3Workflow(object):
     def get_interface_columns(self):
         """
         Returns an array of column names for the interface; defaults to empty so it is not required
-        :return:
+        :return: A list of interface column names
         """
         return []
+
+    def register_standard_output_callback(self, callback):
+        """
+        Used to register the callback function from the UI for standard output from this workflow.
+        This function is not to be inherited by derived workflows unless they are doing something really odd.
+        Workflows should simply use self.callback(message) to send messages as necessary to the GUI during a workflow.
+
+        :param callback: A function to be called with a message.  Formulation: callback = f(str: s)
+        :return: None
+        """
+        self.callback = callback
 
     def main(self, run_directory, file_name, args):
         """

--- a/eplaunch/workflows/default/energyplus.py
+++ b/eplaunch/workflows/default/energyplus.py
@@ -137,6 +137,7 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
         return [ColumnNames.Errors, ColumnNames.Warnings, ColumnNames.Runtime, ColumnNames.Version]
 
     def main(self, run_directory, file_name, args):
+
         full_file_path = os.path.join(run_directory, file_name)
         file_name_no_ext, extension = os.path.splitext(file_name)
         if 'workflow location' in args:
@@ -181,12 +182,19 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
                 # and at the very end, add the file to run
                 command_line_args += [file_name]
 
+                self.callback("E+ SI [%s] --- Running EnergyPlus" % file_name)
+
                 # run E+ and gather (for now fake) data
                 process = subprocess.run(
                     command_line_args,
-                    cwd=run_directory
+                    cwd=run_directory,
+                    stdout=subprocess.PIPE
                 )
+
                 time.sleep(5)
+
+                self.callback("E+ SI [%s] --- EnergyPlus Finished" % file_name)
+
                 status_code = process.returncode
 
                 if status_code != 0:

--- a/eplaunch/workflows/default/site_location.py
+++ b/eplaunch/workflows/default/site_location.py
@@ -25,6 +25,8 @@ class SiteLocationWorkflow(BaseEPLaunch3Workflow):
         return [ColumnNames.Location]
 
     def main(self, run_directory, file_name, args):
+        if self.callback:
+            self.callback("In SiteLocationWorkflow.main(), about to process file")
         file_path = os.path.join(run_directory, file_name)
         content = open(file_path).read()
         new_lines = []
@@ -46,6 +48,8 @@ class SiteLocationWorkflow(BaseEPLaunch3Workflow):
                 break
         else:
             location_name = 'Unknown'
+        if self.callback:
+            self.callback("Completed SiteLocationWorkflow.main()")
         return EPLaunch3WorkflowResponse(
             success=True,
             message='Parsed Location object successfully',

--- a/eplaunch/workflows/manager.py
+++ b/eplaunch/workflows/manager.py
@@ -4,8 +4,9 @@ import os
 
 
 class WorkflowDetail:
-    def __init__(self, workflow_instance, description, is_energyplus, version_id):
+    def __init__(self, workflow_instance, workflow_directory, description, is_energyplus, version_id):
         self.workflow_instance = workflow_instance
+        self.workflow_directory = workflow_directory
         self.description = description
         self.is_energyplus = is_energyplus
         self.version_id = version_id
@@ -81,6 +82,7 @@ def get_workflows(external_workflow_directories):
 
                     work_flows.append(WorkflowDetail(
                         workflow_instance,
+                        workflow_directory,
                         description,
                         dir_is_eplus,
                         version_id


### PR DESCRIPTION
Allowing a workflow to provide messages to the GUI during a run is important, and complex.  The workflows operate on a separate thread than the GUI, so the workflow can't just make updates on the GUI.  

This pull request lays out the framework for allowing workflows to pass messages back to the GUI during a run.  It also modifies the Site:Location built-in and the EnergyPlus SI workflows to use this new callback.  The only requirement of a workflow is to simply call `self.callback` with messages.

Disclaimer: This **does not** try to gather up standard output from individual binaries being run within the workflow, including EnergyPlus.  It's certainly possible to do this, but I gave it an hour of trying different `subprocess.Popen` and `subprocess.communicate` variations, and I never could get the entire output.  I'll try again at a later time.  

Disclaimer 2: For now, this just shows the last message sent in the far right (4th) status bar spot.  

This should suffice for a "phase 1" implementation and let me move on to other work.  Phase 2 will include making an example of E+ standard output coming to the GUI, and a much nicer way to display the output (tabbed modal dialog?).

Fixes #26 