### PR TITLE
Much improved callback support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+tmp_build
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -421,6 +421,8 @@ class EpLaunchFrame(wx.Frame):
     def make_and_show_output_dialog(self, workflow_id):
         this_workflow = self.workflow_workers[workflow_id]
         dlg = OutputDialog(None, title=this_workflow.workflow_instance.name())
+        dlg.set_id(workflow_id)
+        dlg.Bind(wx.EVT_CLOSE, self.output_dialog_closed)
         dlg.set_config(
             json.dumps(
                 {
@@ -432,6 +434,12 @@ class EpLaunchFrame(wx.Frame):
             )
         )
         return dlg
+
+    def output_dialog_closed(self, event):
+        dialog = event.EventObject
+        this_id = dialog.workflow_id
+        dialog.Destroy()
+        del self.workflow_output_dialogs[this_id]
 
     def enable_disable_idf_editor_button(self):
         file_name_no_ext, extension = os.path.splitext(self.current_file_name)
@@ -722,7 +730,8 @@ class EpLaunchFrame(wx.Frame):
 
     def workflow_callback(self, workflow_id, message):
         self.status_bar.SetStatusText(str(message), i=3)
-        self.workflow_output_dialogs[workflow_id].update_output(message)
+        if workflow_id in self.workflow_output_dialogs:
+            self.workflow_output_dialogs[workflow_id].update_output(message)
 
     def handle_exit_box(self, event):
         self.save_config()

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -25,7 +25,7 @@ from eplaunch.workflows import manager as workflow_manager
 # wx callbacks need an event argument even though we usually don't use it, so the next line disables that check
 # noinspection PyUnusedLocal
 class EpLaunchFrame(wx.Frame):
-    DefaultSize = (800, 600)
+    DefaultSize = (650, 600)
 
     def __init__(self, *args, **kwargs):
 
@@ -427,6 +427,13 @@ class EpLaunchFrame(wx.Frame):
         dlg = OutputDialog(None, title=this_workflow.workflow_instance.name())
         dlg.set_id(workflow_id)
         dlg.Bind(wx.EVT_CLOSE, self.output_dialog_closed)
+
+        current_rectangle = self.GetRect()
+        x_right_edge = current_rectangle[0] + current_rectangle[2]
+        y_top = current_rectangle[1]
+        # y_bottom = y_top + current_rectangle[3]
+        dlg.set_x_y(x_right_edge, y_top)
+
         dlg.set_config(
             json.dumps(
                 {
@@ -512,8 +519,7 @@ class EpLaunchFrame(wx.Frame):
         main_app_vertical_sizer.Add(main_left_right_splitter, 1, wx.EXPAND, 0)
 
         # add the status bar
-        self.status_bar = self.CreateStatusBar(4)
-        self.status_bar.SetStatusText("-- workflow output messages appear here --", i=3)
+        self.status_bar = self.CreateStatusBar(3)
 
         # assign the final form's sizer
         self.SetSizer(main_app_vertical_sizer)
@@ -733,7 +739,6 @@ class EpLaunchFrame(wx.Frame):
         wx.CallAfter(publisher.sendMessage, workflow_id, workflow_id=workflow_id, message=message)
 
     def workflow_callback(self, workflow_id, message):
-        self.status_bar.SetStatusText(str(message), i=3)
         if workflow_id in self.workflow_output_dialogs:
             self.workflow_output_dialogs[workflow_id].update_output(message)
 

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -477,7 +477,7 @@ class EpLaunchFrame(wx.Frame):
 
         # add the status bar
         self.status_bar = self.CreateStatusBar(4)
-        self.status_bar.SetStatusText("-- last workflow output message appears here --", i=3)
+        self.status_bar.SetStatusText("-- workflow output messages appear here --", i=3)
 
         # assign the final form's sizer
         self.SetSizer(main_app_vertical_sizer)
@@ -698,7 +698,6 @@ class EpLaunchFrame(wx.Frame):
 
     def workflow_callback(self, message):
         self.status_bar.SetStatusText(str(message), i=3)
-        print("MESSAGE: " + message)
 
     def handle_exit_box(self, event):
         self.save_config()

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -425,7 +425,7 @@ class EpLaunchFrame(wx.Frame):
         max_dialog_vertical_increments = 5.0
         self.workflow_dialog_counter += 1
         if self.workflow_dialog_counter == max_dialog_vertical_increments:
-            self.workflow_dialog_counter = 0
+            self.workflow_dialog_counter = 1
 
         this_workflow = self.workflow_workers[workflow_id]
         dlg = OutputDialog(None, title=this_workflow.workflow_instance.name())
@@ -435,7 +435,6 @@ class EpLaunchFrame(wx.Frame):
         current_rectangle = self.GetRect()
         x_right_edge = current_rectangle[0] + current_rectangle[2]
         y_top = current_rectangle[1]
-        y_bottom = y_top + current_rectangle[3]
         vertical_increment = int(current_rectangle[3] / max_dialog_vertical_increments / 2.0)
         this_x = x_right_edge + 5
         this_y = y_top + vertical_increment * (self.workflow_dialog_counter - 1)

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -90,6 +90,7 @@ class EpLaunchFrame(wx.Frame):
 
         # this is a map of workflow output dialogs, using the uuid as a key
         self.workflow_output_dialogs = {}
+        self.workflow_dialog_counter = 0  # a simple counter ultimately used to place dialogs on the screen
 
         # get the saved workflow directories and update the main workflow list
         self.retrieve_workflow_directories_config()
@@ -421,6 +422,11 @@ class EpLaunchFrame(wx.Frame):
         self.update_num_processes_status()
 
     def make_and_show_output_dialog(self, workflow_id):
+        max_dialog_vertical_increments = 5.0
+        self.workflow_dialog_counter += 1
+        if self.workflow_dialog_counter == max_dialog_vertical_increments:
+            self.workflow_dialog_counter = 0
+
         this_workflow = self.workflow_workers[workflow_id]
         dlg = OutputDialog(None, title=this_workflow.workflow_instance.name())
         dlg.set_id(workflow_id)
@@ -429,8 +435,11 @@ class EpLaunchFrame(wx.Frame):
         current_rectangle = self.GetRect()
         x_right_edge = current_rectangle[0] + current_rectangle[2]
         y_top = current_rectangle[1]
-        # y_bottom = y_top + current_rectangle[3]
-        dlg.set_x_y(x_right_edge, y_top)
+        y_bottom = y_top + current_rectangle[3]
+        vertical_increment = int(current_rectangle[3] / max_dialog_vertical_increments / 2.0)
+        this_x = x_right_edge + 5
+        this_y = y_top + vertical_increment * (self.workflow_dialog_counter - 1)
+        dlg.set_x_y(this_x, this_y)
 
         dlg.set_config(
             json.dumps(

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -698,6 +698,7 @@ class EpLaunchFrame(wx.Frame):
 
     def workflow_callback(self, message):
         self.status_bar.SetStatusText(str(message), i=3)
+        print("MESSAGE: " + message)
 
     def handle_exit_box(self, event):
         self.save_config()

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -421,7 +421,16 @@ class EpLaunchFrame(wx.Frame):
     def make_and_show_output_dialog(self, workflow_id):
         this_workflow = self.workflow_workers[workflow_id]
         dlg = OutputDialog(None, title=this_workflow.workflow_instance.name())
-        dlg.set_config(json.dumps({'config:': 'stuff'}, indent=2))
+        dlg.set_config(
+            json.dumps(
+                {
+                    'workflow_name:': self.workflow_workers[workflow_id].workflow_instance.name(),
+                    'file_name:': self.workflow_workers[workflow_id].file_name,
+                    'directory:': self.workflow_workers[workflow_id].run_directory,
+                },
+                indent=2
+            )
+        )
         return dlg
 
     def enable_disable_idf_editor_button(self):

--- a/eplaunch/interface/workflow_output_dialog.py
+++ b/eplaunch/interface/workflow_output_dialog.py
@@ -1,0 +1,58 @@
+import wx
+
+
+class Dialog(wx.Frame):
+
+    def __init__(self, *args, **kwargs):
+        super(Dialog, self).__init__(*args, **kwargs)
+
+        self.txt_config = None
+        self.txt_output = None
+        self.btn_exit = None
+
+        self.initialize_ui()
+
+    def initialize_ui(self):
+        panel_main = wx.Panel(self, style=wx.BORDER_RAISED)
+        sizer_main = wx.BoxSizer(wx.VERTICAL)
+
+        self.txt_config = wx.TextCtrl(panel_main, -1, style=wx.TE_READONLY | wx.TE_MULTILINE | wx.HSCROLL)
+        self.txt_output = wx.TextCtrl(panel_main, -1, style=wx.TE_READONLY | wx.TE_MULTILINE | wx.HSCROLL)
+        self.btn_exit = wx.Button(panel_main, label="Close Dialog")
+        self.Bind(wx.EVT_BUTTON, self.handle_close, self.btn_exit)
+
+        sizer_main.Add((0, 10))
+
+        sizer_config = wx.BoxSizer(wx.HORIZONTAL)
+        sizer_config.Add((10, 0), proportion=1)
+        sizer_config.Add(self.txt_config, proportion=10, flag=wx.EXPAND)
+        sizer_config.Add((10, 0), proportion=1)
+        sizer_main.Add(sizer_config, proportion=2, flag=wx.EXPAND)
+
+        sizer_main.Add((0, 10))
+
+        sizer_output = wx.BoxSizer(wx.HORIZONTAL)
+        sizer_output.Add((10, 0), proportion=1)
+        sizer_output.Add(self.txt_output, proportion=10, flag=wx.EXPAND)
+        sizer_output.Add((10, 0), proportion=1)
+        sizer_main.Add(sizer_output, proportion=5, flag=wx.EXPAND)
+
+        sizer_main.Add((0, 10))
+
+        sizer_main.Add(self.btn_exit, proportion=1, flag=wx.ALIGN_CENTER)
+
+        sizer_main.Add((0, 10))
+
+        panel_main.SetSizer(sizer_main)
+        self.SetSize((400, 500))
+        self.Centre()
+        self.Show(True)
+
+    def set_config(self, text):
+        self.txt_config.SetValue(text)
+
+    def update_output(self, message):
+        self.txt_output.AppendText(message + '\n')
+
+    def handle_close(self, e):
+        self.Destroy()

--- a/eplaunch/interface/workflow_output_dialog.py
+++ b/eplaunch/interface/workflow_output_dialog.py
@@ -9,6 +9,7 @@ class Dialog(wx.Frame):
         self.txt_config = None
         self.txt_output = None
         self.btn_exit = None
+        self.workflow_id = None
 
         self.initialize_ui()
 
@@ -53,6 +54,9 @@ class Dialog(wx.Frame):
         self.Centre()
         self.Show(True)
 
+    def set_id(self, workflow_id):
+        self.workflow_id = workflow_id
+
     def set_config(self, text):
         self.txt_config.SetValue(text)
 
@@ -60,4 +64,4 @@ class Dialog(wx.Frame):
         self.txt_output.AppendText(message + '\n')
 
     def handle_close(self, e):
-        self.Destroy()
+        self.Close(True)

--- a/eplaunch/interface/workflow_output_dialog.py
+++ b/eplaunch/interface/workflow_output_dialog.py
@@ -13,11 +13,16 @@ class Dialog(wx.Frame):
         self.initialize_ui()
 
     def initialize_ui(self):
+        monospace_text = wx.TextAttr()
+        monospace_text.SetFontFamily(wx.FONTFAMILY_TELETYPE)
+
         panel_main = wx.Panel(self, style=wx.BORDER_RAISED)
         sizer_main = wx.BoxSizer(wx.VERTICAL)
 
         self.txt_config = wx.TextCtrl(panel_main, -1, style=wx.TE_READONLY | wx.TE_MULTILINE | wx.HSCROLL)
+        self.txt_config.SetDefaultStyle(monospace_text)
         self.txt_output = wx.TextCtrl(panel_main, -1, style=wx.TE_READONLY | wx.TE_MULTILINE | wx.HSCROLL)
+        self.txt_output.SetDefaultStyle(monospace_text)
         self.btn_exit = wx.Button(panel_main, label="Close Dialog")
         self.Bind(wx.EVT_BUTTON, self.handle_close, self.btn_exit)
 
@@ -44,7 +49,7 @@ class Dialog(wx.Frame):
         sizer_main.Add((0, 10))
 
         panel_main.SetSizer(sizer_main)
-        self.SetSize((400, 500))
+        self.SetSize((500, 500))
         self.Centre()
         self.Show(True)
 

--- a/eplaunch/interface/workflow_output_dialog.py
+++ b/eplaunch/interface/workflow_output_dialog.py
@@ -31,7 +31,7 @@ class Dialog(wx.Frame):
 
         sizer_config = wx.BoxSizer(wx.HORIZONTAL)
         sizer_config.Add((10, 0), proportion=1)
-        sizer_config.Add(self.txt_config, proportion=10, flag=wx.EXPAND)
+        sizer_config.Add(self.txt_config, proportion=12, flag=wx.EXPAND)
         sizer_config.Add((10, 0), proportion=1)
         sizer_main.Add(sizer_config, proportion=2, flag=wx.EXPAND)
 
@@ -39,7 +39,7 @@ class Dialog(wx.Frame):
 
         sizer_output = wx.BoxSizer(wx.HORIZONTAL)
         sizer_output.Add((10, 0), proportion=1)
-        sizer_output.Add(self.txt_output, proportion=10, flag=wx.EXPAND)
+        sizer_output.Add(self.txt_output, proportion=12, flag=wx.EXPAND)
         sizer_output.Add((10, 0), proportion=1)
         sizer_main.Add(sizer_output, proportion=5, flag=wx.EXPAND)
 

--- a/eplaunch/interface/workflow_output_dialog.py
+++ b/eplaunch/interface/workflow_output_dialog.py
@@ -57,6 +57,9 @@ class Dialog(wx.Frame):
     def set_id(self, workflow_id):
         self.workflow_id = workflow_id
 
+    def set_x_y(self, x, y):
+        self.SetPosition((x, y))
+
     def set_config(self, text):
         self.txt_config.SetValue(text)
 

--- a/eplaunch/interface/workflow_processing.py
+++ b/eplaunch/interface/workflow_processing.py
@@ -26,12 +26,14 @@ class ResultEvent(wx.PyEvent):
 class WorkflowThread(threading.Thread):
     """Worker Thread Class."""
 
-    def __init__(self, identifier, notify_window, workflow_instance, run_directory, file_name, main_args):
+    def __init__(self, identifier, notify_window, workflow_instance,
+                 run_directory, file_name, main_args):
         super().__init__()
         self._notify_window = notify_window
         self._want_abort = 0
         self.id = identifier
         self.workflow_instance = workflow_instance
+        self.workflow_directory = main_args['workflow location']
         self.run_directory = run_directory
         self.file_name = file_name
         self.workflow_main_args = main_args

--- a/eplaunch/workflows/base.py
+++ b/eplaunch/workflows/base.py
@@ -17,7 +17,8 @@ class BaseEPLaunch3Workflow(object):
     output_toolbar_order = None
 
     def __init__(self):
-        self.callback = None
+        self._callback = None
+        self.publisher = None
         self.my_id = None
 
     def name(self):
@@ -46,18 +47,31 @@ class BaseEPLaunch3Workflow(object):
         """
         return []
 
-    def register_standard_output_callback(self, workflow_id, callback):
+    def register_standard_output_callback(self, workflow_id, publisher, callback):
         """
         Used to register the callback function from the UI for standard output from this workflow.
         This function is not to be inherited by derived workflows unless they are doing something really odd.
         Workflows should simply use self.callback(message) to send messages as necessary to the GUI during a workflow.
 
         :param workflow_id: A unique ID assigned by the program in order to track workflows
-        :param callback: A function to be called with a message.  Formulation: callback = f(str: s)
+        :param publisher: A publisher instance for message brokering to the GUI
+        :param callback: The GUI function to be called with message updates
         :return: None
         """
         self.my_id = workflow_id
-        self.callback = callback
+        self.publisher = publisher
+        self._callback = callback
+
+    def callback(self, message):
+        """
+        This is the actual callback function that workflows can call when they have an update.
+        Internally here there are some other parameters passed up, but that is just to further isolate the users
+        from having to pass extra data during their own calls
+
+        :param message: A message to be sent to the GUI from the workflow
+        :return: None
+        """
+        self._callback(self.my_id, self.publisher, message)
 
     def main(self, run_directory, file_name, args):
         """

--- a/eplaunch/workflows/base.py
+++ b/eplaunch/workflows/base.py
@@ -18,7 +18,6 @@ class BaseEPLaunch3Workflow(object):
 
     def __init__(self):
         self._callback = None
-        self.publisher = None
         self.my_id = None
 
     def name(self):
@@ -47,19 +46,17 @@ class BaseEPLaunch3Workflow(object):
         """
         return []
 
-    def register_standard_output_callback(self, workflow_id, publisher, callback):
+    def register_standard_output_callback(self, workflow_id, callback):
         """
         Used to register the callback function from the UI for standard output from this workflow.
         This function is not to be inherited by derived workflows unless they are doing something really odd.
         Workflows should simply use self.callback(message) to send messages as necessary to the GUI during a workflow.
 
         :param workflow_id: A unique ID assigned by the program in order to track workflows
-        :param publisher: A publisher instance for message brokering to the GUI
         :param callback: The GUI function to be called with message updates
         :return: None
         """
         self.my_id = workflow_id
-        self.publisher = publisher
         self._callback = callback
 
     def callback(self, message):
@@ -71,7 +68,7 @@ class BaseEPLaunch3Workflow(object):
         :param message: A message to be sent to the GUI from the workflow
         :return: None
         """
-        self._callback(self.my_id, self.publisher, message)
+        self._callback(self.my_id, message)
 
     def main(self, run_directory, file_name, args):
         """

--- a/eplaunch/workflows/base.py
+++ b/eplaunch/workflows/base.py
@@ -1,3 +1,6 @@
+import subprocess
+
+
 class EPLaunch3WorkflowResponse(object):
 
     def __init__(self, success, message, column_data, **extra_data):
@@ -59,3 +62,13 @@ class BaseEPLaunch3Workflow(object):
         :return: Should return an EPLaunch3WorkflowResponse instance
         """
         raise NotImplementedError("main function needs to be implemented in derived workflow class")
+
+    @staticmethod
+    def execute_for_callback(cmd, cwd):
+        popen = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, universal_newlines=True)
+        for stdout_line in iter(popen.stdout.readline, ""):
+            yield stdout_line.strip()
+        popen.stdout.close()
+        return_code = popen.wait()
+        if return_code:
+            raise subprocess.CalledProcessError(return_code, cmd)

--- a/eplaunch/workflows/base.py
+++ b/eplaunch/workflows/base.py
@@ -18,6 +18,7 @@ class BaseEPLaunch3Workflow(object):
 
     def __init__(self):
         self.callback = None
+        self.my_id = None
 
     def name(self):
         raise NotImplementedError("name function needs to be implemented in derived workflow class")
@@ -45,15 +46,17 @@ class BaseEPLaunch3Workflow(object):
         """
         return []
 
-    def register_standard_output_callback(self, callback):
+    def register_standard_output_callback(self, workflow_id, callback):
         """
         Used to register the callback function from the UI for standard output from this workflow.
         This function is not to be inherited by derived workflows unless they are doing something really odd.
         Workflows should simply use self.callback(message) to send messages as necessary to the GUI during a workflow.
 
+        :param workflow_id: A unique ID assigned by the program in order to track workflows
         :param callback: A function to be called with a message.  Formulation: callback = f(str: s)
         :return: None
         """
+        self.my_id = workflow_id
         self.callback = callback
 
     def main(self, run_directory, file_name, args):

--- a/eplaunch/workflows/default/energyplus.py
+++ b/eplaunch/workflows/default/energyplus.py
@@ -182,8 +182,6 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
                 # and at the very end, add the file to run
                 command_line_args += [file_name]
 
-                # self.callback("E+ SI [%s] --- Running EnergyPlus" % file_name)
-
                 # run E+ and gather data
                 try:
                     for message in BaseEPLaunch3Workflow.execute_for_callback(command_line_args, run_directory):
@@ -195,8 +193,6 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
                         message="EnergyPlus failed for file: %s!" % full_file_path,
                         column_data={}
                     )
-
-                # self.callback("E+ SI [%s] --- EnergyPlus Finished" % file_name)
 
                 end_file_name = "{0}.end".format(file_name_no_ext)
                 end_file_path = os.path.join(run_directory, end_file_name)

--- a/eplaunch/workflows/default/energyplus.py
+++ b/eplaunch/workflows/default/energyplus.py
@@ -143,13 +143,13 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
         if 'workflow location' in args:
             energyplus_root_folder, _ = os.path.split(args['workflow location'])
             if platform.system() == 'Windows':
-                self.EnergyPlusBinary = os.path.join(energyplus_root_folder, 'energyplus.exe')
+                energyplus_binary = os.path.join(energyplus_root_folder, 'energyplus.exe')
             else:
-                self.EnergyPlusBinary = os.path.join(energyplus_root_folder, 'energyplus')
-            if not os.path.exists(self.EnergyPlusBinary):
+                energyplus_binary = os.path.join(energyplus_root_folder, 'energyplus')
+            if not os.path.exists(energyplus_binary):
                 return EPLaunch3WorkflowResponse(
                     success=False,
-                    message="EnergyPlus binary not found: {}!".format(self.EnergyPlusBinary),
+                    message="EnergyPlus binary not found: {}!".format(energyplus_binary),
                     column_data=[]
                 )
         else:
@@ -165,7 +165,7 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
             if numeric_version >= 80900:
 
                 # start with the binary name, obviously
-                command_line_args = [self.EnergyPlusBinary]
+                command_line_args = [energyplus_binary]
 
                 # need to run readvars
                 command_line_args += ['--readvars']
@@ -268,13 +268,13 @@ class EnergyPlusWorkflowIP(BaseEPLaunch3Workflow):
         if 'workflow location' in args:
             energyplus_root_folder, _ = os.path.split(args['workflow location'])
             if platform.system() == 'Windows':
-                self.EnergyPlusBinary = os.path.join(energyplus_root_folder, 'energyplus.exe')
+                energyplus_binary = os.path.join(energyplus_root_folder, 'energyplus.exe')
             else:
-                self.EnergyPlusBinary = os.path.join(energyplus_root_folder, 'energyplus')
-            if not os.path.exists(self.EnergyPlusBinary):
+                energyplus_binary = os.path.join(energyplus_root_folder, 'energyplus')
+            if not os.path.exists(energyplus_binary):
                 return EPLaunch3WorkflowResponse(
                     success=False,
-                    message="EnergyPlus binary not found: {}!".format(self.EnergyPlusBinary),
+                    message="EnergyPlus binary not found: {}!".format(energyplus_binary),
                     column_data=[]
                 )
         else:
@@ -290,7 +290,7 @@ class EnergyPlusWorkflowIP(BaseEPLaunch3Workflow):
             if numeric_version >= 80900:
 
                 # start with the binary name, obviously
-                command_line_args = [self.EnergyPlusBinary]
+                command_line_args = [energyplus_binary]
 
                 # need to run readvars
                 command_line_args += ['--readvars']

--- a/eplaunch/workflows/default/energyplus.py
+++ b/eplaunch/workflows/default/energyplus.py
@@ -184,25 +184,19 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
 
                 self.callback("E+ SI [%s] --- Running EnergyPlus" % file_name)
 
-                # run E+ and gather (for now fake) data
-                process = subprocess.run(
-                    command_line_args,
-                    cwd=run_directory,
-                    stdout=subprocess.PIPE
-                )
-
-                time.sleep(5)
-
-                self.callback("E+ SI [%s] --- EnergyPlus Finished" % file_name)
-
-                status_code = process.returncode
-
-                if status_code != 0:
+                # run E+ and gather data
+                try:
+                    for message in BaseEPLaunch3Workflow.execute_for_callback(command_line_args, run_directory):
+                        self.callback(message)
+                except subprocess.CalledProcessError:
+                    self.callback("E+ FAILED")
                     return EPLaunch3WorkflowResponse(
                         success=False,
                         message="EnergyPlus failed for file: %s!" % full_file_path,
                         column_data={}
                     )
+
+                self.callback("E+ SI [%s] --- EnergyPlus Finished" % file_name)
 
                 end_file_name = "{0}.end".format(file_name_no_ext)
                 end_file_path = os.path.join(run_directory, end_file_name)

--- a/eplaunch/workflows/default/energyplus.py
+++ b/eplaunch/workflows/default/energyplus.py
@@ -182,7 +182,7 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
                 # and at the very end, add the file to run
                 command_line_args += [file_name]
 
-                self.callback("E+ SI [%s] --- Running EnergyPlus" % file_name)
+                # self.callback("E+ SI [%s] --- Running EnergyPlus" % file_name)
 
                 # run E+ and gather data
                 try:
@@ -196,7 +196,7 @@ class EnergyPlusWorkflowSI(BaseEPLaunch3Workflow):
                         column_data={}
                     )
 
-                self.callback("E+ SI [%s] --- EnergyPlus Finished" % file_name)
+                # self.callback("E+ SI [%s] --- EnergyPlus Finished" % file_name)
 
                 end_file_name = "{0}.end".format(file_name_no_ext)
                 end_file_path = os.path.join(run_directory, end_file_name)

--- a/eplaunch/workflows/default/site_location.py
+++ b/eplaunch/workflows/default/site_location.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from eplaunch.workflows.base import BaseEPLaunch3Workflow, EPLaunch3WorkflowResponse
 
@@ -25,7 +26,14 @@ class SiteLocationWorkflow(BaseEPLaunch3Workflow):
         return [ColumnNames.Location]
 
     def main(self, run_directory, file_name, args):
-        self.callback(self.my_id, "In SiteLocationWorkflow.main(), about to process file")
+        self.callback("In SiteLocationWorkflow.main(), about to process file")
+        self.callback("About to start the soothing breathing phase")
+        for i in range(7):
+            time.sleep(1)
+            self.callback("Inhale")
+            time.sleep(1)
+            self.callback("Exhale")
+        self.callback("Done breathing")
         file_path = os.path.join(run_directory, file_name)
         content = open(file_path).read()
         new_lines = []
@@ -47,7 +55,7 @@ class SiteLocationWorkflow(BaseEPLaunch3Workflow):
                 break
         else:
             location_name = 'Unknown'
-        self.callback(self.my_id, "Completed SiteLocationWorkflow.main()")
+        self.callback("Completed SiteLocationWorkflow.main()")
         return EPLaunch3WorkflowResponse(
             success=True,
             message='Parsed Location object successfully',

--- a/eplaunch/workflows/default/site_location.py
+++ b/eplaunch/workflows/default/site_location.py
@@ -25,8 +25,7 @@ class SiteLocationWorkflow(BaseEPLaunch3Workflow):
         return [ColumnNames.Location]
 
     def main(self, run_directory, file_name, args):
-        if self.callback:
-            self.callback("In SiteLocationWorkflow.main(), about to process file")
+        self.callback(self.my_id, "In SiteLocationWorkflow.main(), about to process file")
         file_path = os.path.join(run_directory, file_name)
         content = open(file_path).read()
         new_lines = []
@@ -48,8 +47,7 @@ class SiteLocationWorkflow(BaseEPLaunch3Workflow):
                 break
         else:
             location_name = 'Unknown'
-        if self.callback:
-            self.callback("Completed SiteLocationWorkflow.main()")
+        self.callback(self.my_id, "Completed SiteLocationWorkflow.main()")
         return EPLaunch3WorkflowResponse(
             success=True,
             message='Parsed Location object successfully',

--- a/eplaunch/workflows/manager.py
+++ b/eplaunch/workflows/manager.py
@@ -1,12 +1,17 @@
-from importlib import util as import_util
 import inspect
 import os
+from importlib import util as import_util
 
 
 class WorkflowDetail:
-    def __init__(self, workflow_instance, workflow_directory, description, is_energyplus, version_id):
-        self.workflow_instance = workflow_instance
-        self.workflow_directory = workflow_directory
+    def __init__(self, workflow_class, name, output_suffixes, file_types, columns,
+                 directory, description, is_energyplus, version_id):
+        self.workflow_class = workflow_class
+        self.name = name
+        self.output_suffixes = output_suffixes
+        self.file_types = file_types
+        self.columns = columns
+        self.workflow_directory = directory
         self.description = description
         self.is_energyplus = is_energyplus
         self.version_id = version_id
@@ -62,6 +67,8 @@ def get_workflows(external_workflow_directories):
                     workflow_instance = this_class_type()
                     workflow_name = workflow_instance.name()
                     workflow_file_types = workflow_instance.get_file_types()
+                    workflow_output_suffixes = workflow_instance.get_output_suffixes()
+                    workflow_columns = workflow_instance.get_interface_columns()
 
                     file_type_string = "("
                     first = True
@@ -80,13 +87,19 @@ def get_workflows(external_workflow_directories):
                     elif built_in_workflow_directory == workflow_directory:
                         description += ' (builtin)'
 
-                    work_flows.append(WorkflowDetail(
-                        workflow_instance,
-                        workflow_directory,
-                        description,
-                        dir_is_eplus,
-                        version_id
-                    ))
+                    work_flows.append(
+                        WorkflowDetail(
+                            this_class_type,
+                            workflow_name,
+                            workflow_output_suffixes,
+                            workflow_file_types,
+                            workflow_columns,
+                            workflow_directory,
+                            description,
+                            dir_is_eplus,
+                            version_id
+                        )
+                    )
 
     work_flows.sort(key=lambda w: w.description)
     return work_flows


### PR DESCRIPTION
I got some caffeine, and decided to flesh out the callbacks.  For one thing, the E+ binary I was calling earlier today was fracked somehow and it was messing up stdout, so I spent hours trying Python fixes when it was technically unfixable.  Gross.

Anyway, now the output comes line-by-line...if you run a long running input file (think `RefBldgHospitalNew2004_Chicago`) you should be able to watch the output go by nice and steady.

And the mechanics for this are so dang smooth now.  There is a static method on the workflow base class called `execute_for_callback`.  It is a generator function that can yield values each time it's called.  In this case it's returning output lines from the command being run.  When combined with the pre-wired `callback` function I added earlier today to the workflow base class, the process for a workflow to provide  output to the GUI has reduced to this:

```python
try:
    for message in BaseEPLaunch3Workflow.execute_for_callback(['ping', '-c', '5', 'google.com'], '/home'):
        self.callback(message)
    return EPLaunch3WorkflowResponse(True, 'Ping Complete', {})
except subprocess.CalledProcessError:
    return EPLaunch3WorkflowResponse(False, 'Not sure why but it failed', {})
```

In a real-world workflow, you'd probably provide more diagnostic data during a run:

```python
self.callback("Hey I'm going to run a PING now")
try:
    for message in BaseEPLaunch3Workflow.execute_for_callback(['ping', '-c', '5', 'google.com'], '/home'):
        self.callback(message)
    self.callback("Hey PING is done now")
    # parse some output into a variable called responsetime
    return EPLaunch3WorkflowResponse(True, 'Ping Complete', {'time': responsetime})
except subprocess.CalledProcessError:
    self.callback("PING Failed")
    return EPLaunch3WorkflowResponse(False, 'Not sure why but it failed', {})
```


