### PR TITLE
Packaging fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
           dist: trusty
           sudo: required
           python: 3.6
+          services: docker
+          env: TOX_ENV=linux1804
+        - os: linux
+          dist: trusty
+          sudo: required
+          python: 3.6
           env: TOX_ENV=flake8
         - os: linux
           dist: trusty
@@ -37,6 +43,10 @@ before_install: |
     git clone https://github.com/MacPython/terryfy.git
     source terryfy/travis_tools.sh
     get_python_environment macpython 3.6 venv
+  fi
+  if [ "$TOX_ENV" == "linux1804" ]; then
+    docker run -d --name ubuntu-test -v $(pwd):/travis ubuntu:latest tail -f /dev/null
+    docker ps
   fi
 
 install:

--- a/eplaunch/interface/frame.py
+++ b/eplaunch/interface/frame.py
@@ -5,7 +5,7 @@ import uuid
 from gettext import gettext as _
 
 import wx
-from wx.lib.pubsub import pub
+from pubsub import pub
 
 from eplaunch.interface import workflow_directories_dialog
 from eplaunch.interface.externalprograms import EPLaunchExternalPrograms

--- a/eplaunch/tests/utilities/test_version.py
+++ b/eplaunch/tests/utilities/test_version.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from eplaunch.utilities.crossplatform import Platform
 from eplaunch.utilities.version import Version
 
 
@@ -64,6 +65,8 @@ class TestVersion(unittest.TestCase):
         self.assertEqual('', version_string)
         self.assertEqual(0, version_number)
 
+    @unittest.skipUnless(Platform.get_current_platform() == Platform.LINUX,
+                         "Test badly encoded file on Linux systems, test fails on Windows")
     def test_check_energyplus_version_bad_file(self):
         file_path = os.path.join(os.path.dirname(__file__), "Minimal_820.idf")
         is_version_found, version_string, version_number = self.v.check_energyplus_version(file_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,4 +53,5 @@ coveralls==1.1
 coverage==4.2
 cx_Freeze
 nose==1.3.7
+Pypubsub==4.0.0
 tox==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,4 +54,5 @@ coverage==4.2
 cx_Freeze
 nose==1.3.7
 Pypubsub==4.0.0
+pyinstaller
 tox==2.9.1

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VERSION=`grep VERSION eplaunch/__init__.py | cut -d= -f2 | cut -d\" -f2`
-python setup.py build
-tar -zcf EP-Launch-${VERSION}-linux.tar.gz build/exe.linux-x86_64-3.6
+pyinstaller eplaunch.spec
+tar -zcf EP-Launch-${VERSION}-linux.tar.gz dist/EPLaunch
 mkdir tmp_build
 cp EP-Launch-${VERSION}-linux.tar.gz tmp_build

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -2,7 +2,7 @@
 
 VERSION=`grep VERSION eplaunch/__init__.py | cut -d= -f2 | cut -d\" -f2`
 pip install wxpython
-python setup.py bdist_mac
-tar -zcf EP-Launch-${VERSION}-mac.tar.gz build/EP-Launch-0.1.app
+pyinstaller eplaunch.spec
+tar -zcf EP-Launch-${VERSION}-mac.tar.gz dist/EPLaunch
 mkdir tmp_build
 cp EP-Launch-${VERSION}-mac.tar.gz tmp_build

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,23 @@ import sys
 from cx_Freeze import setup as cx_setup, Executable
 
 from eplaunch import NAME, VERSION
+# from eplaunch.utilities.crossplatform import Platform
 
 include_files = []
 default_workflows = glob.glob("eplaunch/workflows/default/site_location.py")
 workflow_tuples = [(x, os.path.join('lib', x)) for x in default_workflows]
 include_files.extend(workflow_tuples)
 
+include_dependencies = []
+#
+# if Platform.get_current_platform() == Platform.LINUX:
+#     include_dependencies.append(("/usr/lib/libpng12.so.0.37.0", "libpng.so.0"))
+
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options = {
-    "packages": ["eplaunch", "os"],
+    "packages": ["eplaunch", "os", "wx", "pubsub.pub"],
     "excludes": ["tkinter"],
-    "include_files": include_files
+    "include_files": include_files + include_dependencies
 }
 
 # GUI applications require a different base on Windows (the default is for a


### PR DESCRIPTION
Packaging is still not quite working right.  I'm now finding that pyinstaller plays nicer with wxPython than `cx_freeze`.  I'm feeling hopeful about using it.  

Notes:
 - I was able to build a package on my Ubuntu 18.04 machine and it runs fine on a raw Ubuntu 18.04 machine - no error messages
 - PyInstaller, like most Linux packagers, does **not** include the GLIBC libraries.  These libraries are forward compatible, so the approach is to just build EP-Launch with the oldest Linux version, and it will generally work fine on newer machines.  Not the other way around.