### PR TITLE
Allow Pip install of EPLaunch

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install Pip Dependencies
       shell: bash
-      run: pip install pyinstaller==5.0 pypubsub ${{ matrix.wxpython }}
+      run: pip install pyinstaller==4.2 pypubsub ${{ matrix.wxpython }}
 
     - name: Build
       shell: bash

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install Pip Dependencies
       shell: bash
-      run: pip install pyinstaller==4.2 pypubsub ${{ matrix.wxpython }}
+      run: pip install pyinstaller==4.4 pypubsub ${{ matrix.wxpython }}
 
     - name: Build
       shell: bash

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install Pip Dependencies
       shell: bash
-      run: pip install pyinstaller pypubsub ${{ matrix.wxpython }}
+      run: pip install pyinstaller==5.0 pypubsub ${{ matrix.wxpython }}
 
     - name: Build
       shell: bash

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include eplaunch/interface/main_icon.ico

--- a/eplaunch/__init__.py
+++ b/eplaunch/__init__.py
@@ -3,5 +3,5 @@
 # If you waste time on it, please add it here:
 # Total wasted time: 12 minutes
 NAME = "EP-Launch"
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 DOCS_URL = "https://ep-launch.readthedocs.io/en/latest/"

--- a/eplaunch/runner.py
+++ b/eplaunch/runner.py
@@ -2,6 +2,12 @@ import gettext
 
 from eplaunch.interface.application import EpLaunchApplication
 
-gettext.install("app")  # replace with the appropriate catalog name
-app = EpLaunchApplication(0)
-app.MainLoop()
+
+def main():
+    gettext.install("app")  # replace with the appropriate catalog name
+    app = EpLaunchApplication(0)
+    app.MainLoop()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,31 @@
-from setuptools import setup
+import codecs
+import os
+from setuptools import setup, find_packages
 
 from eplaunch import NAME, VERSION
+
+this_dir = os.path.abspath(os.path.dirname(__file__))
+with codecs.open(os.path.join(this_dir, 'README.md'), encoding='utf-8') as i_file:
+    long_description = i_file.read()
 
 setup(
     name=NAME,
     version=VERSION,
+    packages=find_packages(exclude=['test', 'tests', 'test.*']),
     description='Graphical Interface and Workflow Manager for EnergyPlus',
     url='https://github.com/NREL/EP-Launch',
     license='ModifiedBSD',
+    author='DOE',
+    author_email='d@d.d',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    test_suite='nose.collector',
+    tests_require=['nose'],
+    keywords='energyplus',
+    include_package_data=True,
+    install_requires=['wxpython', 'pypubsub'],
+    entry_points={
+        'console_scripts': ['eplaunch3=eplaunch.runner:main'],
+    },
+    python_requires='>=3.5',
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup(
     tests_require=['nose'],
     keywords='energyplus',
     include_package_data=True,
-    install_requires=['wxpython', 'pypubsub'],
+    install_requires=['wxpython', 'pypubsub',
+                      # Temporary until wxpython fixes it
+                      'attrdict3'],
     entry_points={
         'console_scripts': ['eplaunch3=eplaunch.runner:main'],
     },


### PR DESCRIPTION
Minor tweaks to allow Pip installing from the repo.  Not intending on posting to PyPi, at least not anytime soon.  This change will enable some Python packaging/testing/prototyping going on ahead of 22.2 release.