### PR TITLE
Add CLI flag to try to open to installed directory

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -4,15 +4,15 @@ on: [push]
 
 jobs:
   flake8:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v2
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Install Pip Dependencies
       run: pip install flake8

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Install Pip Dependencies
       shell: bash

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,14 +10,14 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        os: [ windows-latest, macos-11, ubuntu-20.04, ubuntu-22.04 ]  # macos-12 is not playing well with Tk
+        os: [ windows-latest, macos-13, ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install Pip Dependencies
         run: pip install -r requirements.txt
       - name: Run Tests

--- a/eplaunch/__init__.py
+++ b/eplaunch/__init__.py
@@ -3,5 +3,5 @@
 # If you waste time on it, please add it here:
 # Total wasted time: 12 minutes
 NAME = "energyplus_launch"
-VERSION = "3.7.2"
+VERSION = "3.7.3"
 DOCS_URL = "https://ep-launch.readthedocs.io/en/latest/"

--- a/eplaunch/interface/config.py
+++ b/eplaunch/interface/config.py
@@ -100,8 +100,9 @@ class ConfigManager:
                     ]
                     if called_from_ep_cli:  # if we are called from E+ CLI, set the E+ dir directly from this file path
                         this_file = Path(__file__).resolve()
-                        transition_package_dir = this_file.parent
-                        python_lib_dir = transition_package_dir.parent
+                        interface_dir = this_file.parent
+                        ep_launch_package_dir = interface_dir.parent
+                        python_lib_dir = ep_launch_package_dir.parent
                         eplus_install_dir = python_lib_dir.parent
                         workflow_path = eplus_install_dir / 'workflows'
                         eplus_workflow = workflow_path / 'energyplus.py'

--- a/eplaunch/interface/config.py
+++ b/eplaunch/interface/config.py
@@ -2,6 +2,7 @@ from collections import deque
 from configparser import ConfigParser
 from json import loads, dumps
 from pathlib import Path
+from re import search
 from typing import Any, Dict, List, Optional
 
 
@@ -33,7 +34,7 @@ class ConfigManager:
         self.dir_file_paned_window_sash_position: int = 400
         self.list_group_paned_window_sash_position: int = 500
 
-    def load(self):
+    def load(self, called_from_ep_cli: bool):
         # load the config from the file on disk
         config_file_path = Path.home() / ConfigManager.config_file_name
         if not config_file_path.exists():
@@ -97,6 +98,21 @@ class ConfigManager:
                     self.workflow_directories = [
                         Path(p) for p in config.get('WorkflowDirectories', self.workflow_directories)
                     ]
+                    if called_from_ep_cli:  # if we are called from E+ CLI, set the E+ dir directly from this file path
+                        this_file = Path(__file__).resolve()
+                        transition_package_dir = this_file.parent
+                        python_lib_dir = transition_package_dir.parent
+                        eplus_install_dir = python_lib_dir.parent
+                        workflow_path = eplus_install_dir / 'workflows'
+                        eplus_workflow = workflow_path / 'energyplus.py'
+                        context_pattern = r"EnergyPlus-(\d+\.\d+\.\d+)-([0-9a-f]+)"
+                        context = search(context_pattern, eplus_workflow.read_text())
+                        version = context.group(1)
+                        sha = context.group(2)
+                        self.cur_workflow_name = f"EnergyPlus-{version} SI"
+                        self.cur_workflow_context = f"EnergyPlus-{version}-{sha}"
+                        if workflow_path not in self.workflow_directories:
+                            self.workflow_directories.append(workflow_path)
                     recent_folders = config.get('RecentFolders', self.folders_recent)
                     if recent_folders is not None:
                         for string_path in recent_folders:

--- a/eplaunch/interface/frame_main.py
+++ b/eplaunch/interface/frame_main.py
@@ -45,7 +45,7 @@ class EPLaunchWindow(Tk):
 
     # region Construction and GUI building functions
 
-    def __init__(self):
+    def __init__(self, called_from_ep_cli: bool):
         fixup_taskbar_icon_on_windows(NAME)
         super().__init__(className=NAME)
         # set the form title and icon, basic stuff
@@ -84,7 +84,7 @@ class EPLaunchWindow(Tk):
 
         # create a config manager and load up the saved, or default, configuration
         self.conf = ConfigManager()
-        self.conf.load()
+        self.conf.load(called_from_ep_cli)
 
         # initialize some dir/file selection variables
         self.previous_selected_directory: Optional[Path] = None

--- a/eplaunch/tk_runner.py
+++ b/eplaunch/tk_runner.py
@@ -1,8 +1,8 @@
 from eplaunch.interface.frame_main import EPLaunchWindow
 
 
-def main_gui():
-    EPLaunchWindow().run()
+def main_gui(called_from_ep_cli: bool = False):
+    EPLaunchWindow(called_from_ep_cli).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now that the EnergyPlus CLI can open EP Launch, it would be nice if it automatically added the relative E+ workflows directory and selected the context appropriately.  I already did something similar in the transition tool, this just adds it here.  Basically, if you pass True when you call the main gui function, it will locate itself inside the E+ install tree, find the workflows folder, add it to the known workflow directories, and then try to select that workflow and context.  Version is bumped to prepare a new release.

FYI @JasonGlazer 